### PR TITLE
Use currentDate as base for nextDueDate

### DIFF
--- a/packages/pacman/lib/check-for-updates.ts
+++ b/packages/pacman/lib/check-for-updates.ts
@@ -63,7 +63,7 @@ export async function* checkForUpdatesSingleCycle(
       asyncToArray,
     )
 
-    const nextDueDate = dueDate + period
+    const nextDueDate = currentDate + period
 
     yield {
       updates,


### PR DESCRIPTION
Before, with `dueDate` as base, should `currentDate` be greater than `period` multiple times over, then check-for-updates event would be triggered more than necessary.

Now however, with `currentDate` as base, the event would be triggered only after a `period` amount of time.